### PR TITLE
Chunk groups support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ readme = "README.md"
 edition = "2021"
 
 [dependencies]
-arrayref = "0.3.5"
-arrayvec = "0.7.1"
-blake3 = "1.0.0"
-tokio = { version = "1.24.2", features = [], default-features=false, optional = true }
+arrayref = "0.3"
+arrayvec = "0.7"
+blake3 = "1"
+tokio = { version = "1", features = [], default-features=false, optional = true }
 
 [features]
 # todo: remove before merge
@@ -21,12 +21,12 @@ default = ["tokio_io"]
 tokio_io = ["tokio"]
 
 [dev-dependencies]
-lazy_static = "1.3.0"
-rand = "0.8.4"
-serde = { version = "1.0.97", features = ["derive"] }
-serde_json = "1.0.40"
-tempfile = "3.1.0"
+lazy_static = "1.3"
+rand = "0.8"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tempfile = "3"
 rand_chacha = "0.3.1"
 rand_xorshift = "0.3.0"
 page_size = "0.4.1"
-tokio = { version = "1.24.2", features = ["full"] }
+tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,12 @@ edition = "2021"
 arrayref = "0.3.5"
 arrayvec = "0.7.1"
 blake3 = "1.0.0"
+tokio = { version = "1.24.2", features = [], default-features=false, optional = true }
+
+[features]
+# todo: remove before merge
+default = ["tokio_io"]
+tokio_io = ["tokio"]
 
 [dev-dependencies]
 lazy_static = "1.3.0"
@@ -23,3 +29,4 @@ tempfile = "3.1.0"
 rand_chacha = "0.3.1"
 rand_xorshift = "0.3.0"
 page_size = "0.4.1"
+tokio = { version = "1.24.2", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abao"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Jack O'Connor", "Rüdiger Klaehn"]
 description = "an implementation of BLAKE3 verified streaming"
 license = "CC0-1.0 OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,13 @@ edition = "2021"
 arrayref = "0.3"
 arrayvec = "0.7"
 blake3 = "1"
+futures = { version = "0.3", features = [], default-features = false, optional = true }
 tokio = { version = "1", features = [], default-features=false, optional = true }
 
 [features]
 # todo: remove before merge
 default = ["tokio_io"]
-tokio_io = ["tokio"]
+tokio_io = ["tokio", "futures"]
 
 [dev-dependencies]
 lazy_static = "1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name = "bao"
-version = "0.12.1"
-authors = ["Jack O'Connor"]
+name = "abao"
+version = "0.1.0"
+authors = ["Jack O'Connor", "Rüdiger Klaehn"]
 description = "an implementation of BLAKE3 verified streaming"
 license = "CC0-1.0 OR Apache-2.0"
-repository = "https://github.com/oconnor663/bao"
-documentation = "https://docs.rs/bao"
+repository = "https://github.com/n0-computer/abao"
+documentation = "https://docs.rs/abao"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 arrayref = "0.3.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abao"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Jack O'Connor", "Rüdiger Klaehn"]
 description = "an implementation of BLAKE3 verified streaming"
 license = "CC0-1.0 OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# <a href="#"><img src="docs/bao.svg" alt="Bao" height=100></a> &nbsp; [![Actions Status](https://github.com/oconnor663/bao/workflows/tests/badge.svg)](https://github.com/oconnor663/bao/actions) [![docs.rs](https://docs.rs/bao/badge.svg)](https://docs.rs/bao) [![crates.io](https://img.shields.io/crates/v/bao.svg)](https://crates.io/crates/bao)
+This is a fork of [https://github.com/oconnor663/bao] that adds async support and chunk groups.
 
-[Bao Spec](docs/spec.md) — [Rust Crate](https://crates.io/crates/bao) — [Rust Docs](https://docs.rs/bao)
+# <a href="#"><img src="docs/bao.svg" alt="Bao" height=100></a> &nbsp; [![Actions Status](https://github.com/n0-computer/abao/workflows/tests/badge.svg)](https://github.com/n0-computer/abao/actions) [![docs.rs](https://docs.rs/baoa/badge.svg)](https://docs.rs/baoa) [![crates.io](https://img.shields.io/crates/v/baoa.svg)](https://crates.io/crates/baoa)
+
+[Bao Spec](docs/spec.md) — [Rust Crate](https://crates.io/crates/baoa) — [Rust Docs](https://docs.rs/baoa)
 
 Bao is an implementation of
 [BLAKE3](https://github.com/BLAKE3-team/BLAKE3) verified streaming, as
@@ -14,8 +16,8 @@ while verifying that every byte they read matches the root hash. For the
 details of how this works, see the [Bao spec](docs/spec.md).
 
 This project includes two Rust crates, the
-[`bao`](https://crates.io/crates/bao) library crate and the
-[`bao_bin`](https://crates.io/crates/bao_bin) binary crate. The latter
+[`bao`](https://crates.io/crates/abao) library crate and the
+[`bao_bin`](https://crates.io/crates/abao_bin) binary crate. The latter
 provides the `bao` command line utility.
 
 > **Caution!** Bao is beta cryptography software. It has not been

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 This is a fork of [https://github.com/oconnor663/bao] that adds async support and chunk groups.
 
-# <a href="#"><img src="docs/bao.svg" alt="Bao" height=100></a> &nbsp; [![Actions Status](https://github.com/n0-computer/abao/workflows/tests/badge.svg)](https://github.com/n0-computer/abao/actions) [![docs.rs](https://docs.rs/baoa/badge.svg)](https://docs.rs/baoa) [![crates.io](https://img.shields.io/crates/v/baoa.svg)](https://crates.io/crates/baoa)
+# <a href="#"><img src="docs/bao.svg" alt="Bao" height=100></a> &nbsp; [![Actions Status](https://github.com/n0-computer/abao/workflows/tests/badge.svg)](https://github.com/n0-computer/abao/actions) [![docs.rs](https://docs.rs/abao/badge.svg)](https://docs.rs/abao) [![crates.io](https://img.shields.io/crates/v/abao.svg)](https://crates.io/crates/abao)
 
-[Bao Spec](docs/spec.md) — [Rust Crate](https://crates.io/crates/baoa) — [Rust Docs](https://docs.rs/baoa)
+[Bao Spec](docs/spec.md) — [Rust Crate](https://crates.io/crates/abao) — [Rust Docs](https://docs.rs/abao)
 
 Bao is an implementation of
 [BLAKE3](https://github.com/BLAKE3-team/BLAKE3) verified streaming, as

--- a/bao_bin/Cargo.toml
+++ b/bao_bin/Cargo.toml
@@ -19,7 +19,7 @@ rayon = ["blake3/rayon"]
 
 [dependencies]
 arrayref = "0.3.5"
-bao = { path = "..", version = "0.12" }
+abao = { path = "..", version = "0.1" }
 blake3 = "1.0.0"
 docopt = "1.1.0"
 failure = "0.1.5"

--- a/bao_bin/src/main.rs
+++ b/bao_bin/src/main.rs
@@ -5,6 +5,7 @@ use std::fs::{File, OpenOptions};
 use std::io;
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
+use abao as bao;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -205,7 +206,7 @@ fn slice(args: &Args) -> Result<(), Error> {
     let mut extractor;
     if args.flag_outboard.is_some() {
         outboard = open_input(&args.flag_outboard)?;
-        extractor = bao::encode::SliceExtractor::new_outboard(
+        extractor = abao::encode::SliceExtractor::new_outboard(
             input.require_file()?,
             outboard.require_file()?,
             args.arg_start,
@@ -213,7 +214,7 @@ fn slice(args: &Args) -> Result<(), Error> {
         );
     } else {
         extractor =
-            bao::encode::SliceExtractor::new(input.require_file()?, args.arg_start, args.arg_count);
+            abao::encode::SliceExtractor::new(input.require_file()?, args.arg_start, args.arg_count);
     }
     copy_reader_to_writer(&mut extractor, &mut output)?;
     Ok(())

--- a/bao_bin/tests/test.rs
+++ b/bao_bin/tests/test.rs
@@ -56,7 +56,7 @@ fn test_hash_many() {
 fn assert_hash_mismatch(output: &std::process::Output) {
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains(bao::decode::Error::HashMismatch.to_string().as_str()));
+    assert!(stderr.contains(abao::decode::Error::HashMismatch.to_string().as_str()));
 }
 
 #[test]

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -2,7 +2,7 @@
 
 extern crate test;
 
-use bao::{decode, encode};
+use abao::{decode, encode};
 use rand::prelude::*;
 use std::io::prelude::*;
 use std::io::{Cursor, SeekFrom::Start};

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -657,6 +657,7 @@ mod tokio_io {
     ///
     /// This is the decoder, but it is a separate type so it can be private.
     /// The public AsyncDecoder just wraps this.
+    #[derive(Debug)]
     enum DecoderState<T: AsyncRead + Unpin, O: AsyncRead + Unpin> {
         /// we are reading from the underlying reader
         Reading(BoxedDecoderShared<T, O>),
@@ -716,6 +717,7 @@ mod tokio_io {
         }
     }
 
+    #[derive(Debug)]
     pub struct AsyncDecoder<T: AsyncRead + Unpin, O: AsyncRead + Unpin>(DecoderState<T, O>);
 
     impl<T: AsyncRead + Unpin> AsyncDecoder<T, T> {
@@ -1224,6 +1226,7 @@ fn add_offset(position: u64, offset: i64) -> io::Result<u64> {
 /// # Ok(())
 /// # }
 /// ```
+#[derive(Debug)]
 pub struct SliceDecoder<T: Read> {
     shared: DecoderShared<T, T>,
     slice_start: u64,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -460,12 +460,13 @@ impl<T, O> fmt::Debug for DecoderShared<T, O> {
 mod tokio_io {
 
     use super::{DecoderShared, Hash, NextRead};
+    use futures::{future, ready};
     use std::{
         cmp,
         convert::TryInto,
         io,
         pin::Pin,
-        task::{ready, Context, Poll},
+        task::{Context, Poll},
     };
     use tokio::io::{AsyncRead, ReadBuf};
 
@@ -853,7 +854,7 @@ mod tokio_io {
         /// we are at the start.
         pub async fn read_size(&mut self) -> io::Result<u64> {
             if let SliceDecoderState::Reading(state) = &mut self.0 {
-                std::future::poll_fn(|cx| state.shared.poll_read_header(cx)).await?;
+                future::poll_fn(|cx| state.shared.poll_read_header(cx)).await?;
             }
             Ok(match &self.0 {
                 SliceDecoderState::Reading(state) => state.content_len().unwrap(),

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -1014,6 +1014,7 @@ pub(crate) enum LenNext {
 /// # Ok(())
 /// # }
 /// ```
+#[derive(Debug)]
 pub struct SliceExtractor<T: Read + Seek, O: Read + Seek> {
     input: T,
     outboard: Option<O>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,9 @@
 //! # Ok(())
 //! # }
 //! ```
-
 #![forbid(unsafe_code)]
+#![deny(missing_docs)]
+#![deny(rustdoc::broken_intra_doc_links)]
 
 pub mod decode;
 pub mod encode;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,14 +15,14 @@
 //!
 //! // Encode some example bytes.
 //! let input = b"some input";
-//! let (encoded, hash) = bao::encode::encode(input);
+//! let (encoded, hash) = abao::encode::encode(input);
 //!
 //! // Decode them with one of the all-at-once functions.
-//! let decoded_at_once = bao::decode::decode(&encoded, &hash)?;
+//! let decoded_at_once = abao::decode::decode(&encoded, &hash)?;
 //!
 //! // Also decode them incrementally.
 //! let mut decoded_incrementally = Vec::new();
-//! let mut decoder = bao::decode::Decoder::new(&*encoded, &hash);
+//! let mut decoder = abao::decode::Decoder::new(&*encoded, &hash);
 //! decoder.read_to_end(&mut decoded_incrementally)?;
 //!
 //! // Assert that we got the same results both times.
@@ -32,7 +32,7 @@
 //! let mut bad_encoded = encoded.clone();
 //! let last_index = bad_encoded.len() - 1;
 //! bad_encoded[last_index] ^= 1;
-//! let err = bao::decode::decode(&bad_encoded, &hash).unwrap_err();
+//! let err = abao::decode::decode(&bad_encoded, &hash).unwrap_err();
 //! assert_eq!(std::io::ErrorKind::InvalidData, err.kind());
 //! # Ok(())
 //! # }

--- a/tests/vector_tests.rs
+++ b/tests/vector_tests.rs
@@ -1,6 +1,6 @@
 //! The tests in this file run bao against the standard set of test vectors.
 
-use bao::Hash;
+use abao::Hash;
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use std::cmp;
@@ -84,7 +84,7 @@ fn make_input(len: usize) -> Vec<u8> {
 #[test]
 fn test_hash_vectors() {
     for case in &TEST_VECTORS.hash {
-        println!("case {:?}", case);
+        println!("case {case:?}");
         let input = make_input(case.input_len);
         let hash = blake3::hash(&input);
         assert_eq!(case.bao_hash, hash.to_hex().to_string());
@@ -108,38 +108,38 @@ fn test_encode_vectors() {
     for case in &TEST_VECTORS.encode {
         println!("input_len {}", case.input_len);
         let input = make_input(case.input_len);
-        let (encoded, hash) = bao::encode::encode(&input);
+        let (encoded, hash) = abao::encode::encode(&input);
         assert_eq!(&*case.bao_hash, &*hash.to_hex());
         assert_eq!(
             case.encoded_blake3,
             blake3::hash(&encoded).to_hex().as_str()
         );
-        let encoded_size = bao::encode::encoded_size(case.input_len as u64) as usize;
+        let encoded_size = abao::encode::encoded_size(case.input_len as u64) as usize;
         assert_eq!(encoded_size, encoded.len());
 
         // Test decoding.
-        let output = bao::decode::decode(&encoded, &hash).unwrap();
+        let output = abao::decode::decode(&encoded, &hash).unwrap();
         assert_eq!(input, output);
 
         // Make sure decoding with a bad hash fails.
         let bad_hash = corrupt_hash(&hash);
-        let err = bao::decode::decode(&encoded, &bad_hash).unwrap_err();
+        let err = abao::decode::decode(&encoded, &bad_hash).unwrap_err();
         assert_eq!(std::io::ErrorKind::InvalidData, err.kind());
 
         // Make sure each corruption point fails the decode.
         for &point in &case.corruptions {
-            println!("corruption {}", point);
+            println!("corruption {point}");
             let mut corrupt = encoded.clone();
             corrupt[point] ^= 1;
             // The error can be either HashMismatch or Truncated, depending on whether the header
             // was corrupted.
-            bao::decode::decode(&corrupt, &hash).unwrap_err();
+            abao::decode::decode(&corrupt, &hash).unwrap_err();
         }
     }
 }
 
 fn decode_outboard(input: &[u8], outboard: &[u8], hash: &Hash) -> io::Result<Vec<u8>> {
-    let mut reader = bao::decode::Decoder::new_outboard(input, outboard, hash);
+    let mut reader = abao::decode::Decoder::new_outboard(input, outboard, hash);
     let mut output = Vec::with_capacity(input.len());
     reader.read_to_end(&mut output)?;
     Ok(output)
@@ -150,13 +150,13 @@ fn test_outboard_vectors() {
     for case in &TEST_VECTORS.outboard {
         println!("input_len {}", case.input_len);
         let input = make_input(case.input_len);
-        let (outboard, hash) = bao::encode::outboard(&input);
+        let (outboard, hash) = abao::encode::outboard(&input);
         assert_eq!(&*case.bao_hash, &*hash.to_hex());
         assert_eq!(
             case.encoded_blake3,
             blake3::hash(&outboard).to_hex().as_str()
         );
-        let outboard_size = bao::encode::outboard_size(case.input_len as u64) as usize;
+        let outboard_size = abao::encode::outboard_size(case.input_len as u64) as usize;
         assert_eq!(outboard_size, outboard.len());
 
         // Test decoding. Currently only the Decoder implements it.
@@ -170,7 +170,7 @@ fn test_outboard_vectors() {
 
         // Make sure each tree corruption point fails the decode.
         for &point in &case.outboard_corruptions {
-            println!("corruption {}", point);
+            println!("corruption {point}");
             let mut corrupt = outboard.clone();
             corrupt[point] ^= 1;
             // The error can be either InvalidData or UnexpectedEof, depending on whether the
@@ -180,7 +180,7 @@ fn test_outboard_vectors() {
 
         // Make sure each input corruption point fails the decode.
         for &point in &case.input_corruptions {
-            println!("corruption {}", point);
+            println!("corruption {point}");
             let mut corrupt = input.clone();
             corrupt[point] ^= 1;
             let err = decode_outboard(&corrupt, &outboard, &hash).unwrap_err();
@@ -194,19 +194,19 @@ fn test_seek_vectors() {
     for case in &TEST_VECTORS.seek {
         println!("\n\ninput_len {}", case.input_len);
         let input = make_input(case.input_len);
-        let (encoded, hash) = bao::encode::encode(&input);
-        let (outboard, outboard_hash) = bao::encode::outboard(&input);
+        let (encoded, hash) = abao::encode::encode(&input);
+        let (outboard, outboard_hash) = abao::encode::outboard(&input);
         assert_eq!(hash, outboard_hash);
 
         // First, test all the different seek points using fresh readers.
         println!();
         for &seek in &case.seek_offsets {
-            println!("seek {}", seek);
+            println!("seek {seek}");
             let capped_seek = cmp::min(seek, input.len());
             let expected_input = &input[capped_seek..];
 
             // Test seeking in the combined mode.
-            let mut combined_reader = bao::decode::Decoder::new(Cursor::new(&encoded), &hash);
+            let mut combined_reader = abao::decode::Decoder::new(Cursor::new(&encoded), &hash);
             combined_reader
                 .seek(io::SeekFrom::Start(seek as u64))
                 .unwrap();
@@ -215,7 +215,7 @@ fn test_seek_vectors() {
             assert_eq!(expected_input, &*combined_output);
 
             // Test seeking in the outboard mode.
-            let mut outboard_reader = bao::decode::Decoder::new_outboard(
+            let mut outboard_reader = abao::decode::Decoder::new_outboard(
                 Cursor::new(&input),
                 Cursor::new(&outboard),
                 &hash,
@@ -238,12 +238,12 @@ fn test_seek_vectors() {
             repeated_seeks.push(x);
             repeated_seeks.push(y);
         }
-        let mut combined_reader = bao::decode::Decoder::new(Cursor::new(&encoded), &hash);
+        let mut combined_reader = abao::decode::Decoder::new(Cursor::new(&encoded), &hash);
         let mut outboard_reader =
-            bao::decode::Decoder::new_outboard(Cursor::new(&input), Cursor::new(&outboard), &hash);
+            abao::decode::Decoder::new_outboard(Cursor::new(&input), Cursor::new(&outboard), &hash);
         println!();
         for &seek in &repeated_seeks {
-            println!("repeated seek {}", seek);
+            println!("repeated seek {seek}");
             let capped_seek = cmp::min(seek, input.len());
             let capped_len = cmp::min(100, input.len() - capped_seek);
             let mut read_buf = [0; 100];
@@ -270,7 +270,7 @@ fn test_seek_vectors() {
 }
 
 fn decode_slice(slice: &[u8], hash: &Hash, start: u64, len: u64) -> io::Result<Vec<u8>> {
-    let mut reader = bao::decode::SliceDecoder::new(slice, hash, start, len);
+    let mut reader = abao::decode::SliceDecoder::new(slice, hash, start, len);
     let mut output = Vec::new();
     reader.read_to_end(&mut output)?;
     Ok(output)
@@ -281,8 +281,8 @@ fn test_slice_vectors() {
     for case in &TEST_VECTORS.slice {
         println!("\n\ninput_len {}", case.input_len);
         let input = make_input(case.input_len);
-        let (encoded, hash) = bao::encode::encode(&input);
-        let (outboard, outboard_hash) = bao::encode::outboard(&input);
+        let (encoded, hash) = abao::encode::encode(&input);
+        let (outboard, outboard_hash) = abao::encode::outboard(&input);
         assert_eq!(hash, outboard_hash);
 
         for slice in &case.slices {
@@ -293,7 +293,7 @@ fn test_slice_vectors() {
 
             // Make sure slicing the combined encoding has the output that it should.
             let mut combined_extractor =
-                bao::encode::SliceExtractor::new(Cursor::new(&encoded), slice.start, slice.len);
+                abao::encode::SliceExtractor::new(Cursor::new(&encoded), slice.start, slice.len);
             let mut combined_slice = Vec::new();
             combined_extractor.read_to_end(&mut combined_slice).unwrap();
             assert_eq!(slice.output_len, combined_slice.len());
@@ -303,7 +303,7 @@ fn test_slice_vectors() {
             );
 
             // Make sure slicing the outboard encoding also gives the right output.
-            let mut outboard_extractor = bao::encode::SliceExtractor::new_outboard(
+            let mut outboard_extractor = abao::encode::SliceExtractor::new_outboard(
                 Cursor::new(&input),
                 Cursor::new(&outboard),
                 slice.start,
@@ -324,7 +324,7 @@ fn test_slice_vectors() {
 
             // Test that each of the corruption points breaks decoding the slice.
             for &point in &slice.corruptions {
-                println!("corruption {}", point);
+                println!("corruption {point}");
                 let mut corrupted = combined_slice.clone();
                 corrupted[point] ^= 1;
                 // The error can be either HashMismatch or Truncated, depending on whether the header


### PR DESCRIPTION
Questions:

- hardcode the chunk group size, or use const generics?
- if hardcode, at what size?

Note: this is not quite as efficient as the original bao branch https://github.com/oconnor663/bao/tree/chunk_groups , because that requires exposing more guts from blake3.  https://github.com/BLAKE3-team/BLAKE3/tree/more_guts