### PR TITLE
tests: don't use hardcoded executable path

### DIFF
--- a/bao_bin/Cargo.toml
+++ b/bao_bin/Cargo.toml
@@ -20,6 +20,7 @@ rayon = ["blake3/rayon"]
 [dependencies]
 arrayref = "0.3.5"
 bao = { path = "..", version = "0.12" }
+assert_cmd = "2.0.16"
 blake3 = "1.0.0"
 docopt = "1.1.0"
 failure = "0.1.5"

--- a/bao_bin/tests/test.rs
+++ b/bao_bin/tests/test.rs
@@ -1,8 +1,7 @@
 use duct::cmd;
 use rand::prelude::*;
-use std::env::consts::EXE_EXTENSION;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Once;
 use tempfile::tempdir;
 
@@ -15,10 +14,7 @@ pub fn bao_exe() -> PathBuf {
             .expect("build failed");
     });
 
-    Path::new("target")
-        .join("debug")
-        .join("bao")
-        .with_extension(EXE_EXTENSION)
+    assert_cmd::cargo::cargo_bin("bao")
 }
 
 #[test]


### PR DESCRIPTION
In certain setups (packaging, where `CARGO_BUILD_TARGET` might be set), the path to the `bao` executable might not be `target/debug/bao`. This PR uses generic functionality from `assert_cmd` instead of the current hardcoded path.